### PR TITLE
Fix initial table rendering.

### DIFF
--- a/arc-0030/README.md
+++ b/arc-0030/README.md
@@ -2,7 +2,7 @@
 arc: 0030
 title: Adding self.parent opcode
 authors: evan@demoxlabs.xyz mike@demoxlabs.xyz
-discussion: ARC-0030: Adding self.parent opcode
+discussion: ARC-0030 Adding self.parent opcode
 topic: Application
 status: Draft
 created: 9/2/2022


### PR DESCRIPTION
It looks like the colon just after ‘ARC-0030’ was confusing the rendered, as colons have significance in separating table cell titles from their contents.

Signed-off-by: Alessandro Coglio <acoglio@aleo.org>