### PR TITLE
Update CI

### DIFF
--- a/arc-0030/README.md
+++ b/arc-0030/README.md
@@ -1,8 +1,8 @@
 ---
-arc: 0030
+arc: 30
 title: Adding self.parent opcode
 authors: evan@demoxlabs.xyz mike@demoxlabs.xyz
-discussion: ARC-0030: Adding self.parent opcode
+discussion: https://github.com/AleoHQ/ARCs/discussions/11
 topic: Application
 status: Draft
 created: 9/2/2022

--- a/parser/index.js
+++ b/parser/index.js
@@ -24,7 +24,7 @@ const ci = () => {
             console.log('Error', err);
             process.exit(1);
         } else {
-            for (let i = 0; i < list.length; i++) {
+            for (let i = 1; i < list.length; i++) {
                 const arcDirectory = list[i];
 
                 /**************************** ****************************/
@@ -56,7 +56,7 @@ const site = () => {
 
             let arcs = {};
 
-            for (let i = 0; i < list.length; i++) {
+            for (let i = 1; i < list.length; i++) {
                 const arcDirectory = list[i];
 
                 /**************************** ****************************/


### PR DESCRIPTION
The previous parser script was failing since ARC-0000 did not meet the requirements.
This updates the script to skip checking the ARC-0000 header.