### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/archive/markdown.yml
+++ b/.github/workflows/archive/markdown.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected